### PR TITLE
Remove outdated advice about `helmfile apply`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,3 @@ Make sure not to upload secrets in here!
 
 Some documentation _might_ be found here: https://chrisproject.org/docs/internal/nerc
 
-## Notes
-
-Use `helmfile sync` instead of `helmfile apply`. See https://github.com/databus23/helm-diff/issues/460#issuecomment-1642653675
-
-


### PR DESCRIPTION
The `helmfile apply` subcommand works fine with the configuration


```yaml
helmDefaults:
  diffArgs: [ --dry-run=server ]
```